### PR TITLE
feat(builtin): Handle len and other builtins in VIR gen

### DIFF
--- a/formal_verification/src/vir_backend/vir_gen/expr_to_vir/builtins.rs
+++ b/formal_verification/src/vir_backend/vir_gen/expr_to_vir/builtins.rs
@@ -1,0 +1,163 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use crate::vir_backend::vir_gen::{
+    build_span_no_id,
+    expr_to_vir::types::{ast_type_to_vir_type, make_unit_vir_type},
+};
+use noirc_errors::Location;
+use noirc_frontend::monomorphization::ast::{Call, Definition, Expression, GlobalId, Type};
+use num_bigint::BigInt;
+use num_traits::Zero;
+use vir::ast::{Constant, Dt, Expr, ExprX, Mode, SpannedTyped, Stmt};
+use vir::ast_util::mk_tuple;
+
+pub type GlobalsMap = BTreeMap<GlobalId, (String, Type, Expression)>;
+pub type ExprConverter = fn(&Expression, Mode, &GlobalsMap) -> Expr;
+pub type StmtConverter = fn(&Expression, Mode, &GlobalsMap) -> Stmt;
+
+pub fn try_handle_builtin_call(
+    call_expr: &Call,
+    mode: Mode,
+    globals: &GlobalsMap,
+    expr_to_vir: ExprConverter,
+    expr_to_stmt: StmtConverter,
+) -> Option<Expr> {
+    let Expression::Ident(function_ident) = call_expr.func.as_ref() else {
+        return None;
+    };
+    let Definition::Builtin(name) = &function_ident.definition else {
+        return None;
+    };
+
+    match name.as_str() {
+        "len" | "array_len" => builtin_len(call_expr),
+        "zeroed" => builtin_zeroed(call_expr),
+        "checked_transmute" => builtin_checked_transmute(call_expr, mode, globals, expr_to_vir),
+        "black_box" => builtin_black_box(call_expr, mode, globals, expr_to_vir),
+        "array_refcount" | "slice_refcount" | "slice_push_back" | "slice_push_front"
+        | "slice_pop_back" | "slice_pop_front" | "slice_insert" | "slice_remove" => {
+            builtin_unit_noop(call_expr, mode, globals, expr_to_stmt, name)
+        }
+        _ => None,
+    }
+}
+
+fn builtin_len(call_expr: &Call) -> Option<Expr> {
+    if call_expr.arguments.len() != 1 {
+        panic!("Expected builtin `len` to receive a single argument");
+    }
+
+    let arg_expr = call_expr.arguments.first()?;
+    let Some(arg_type) = arg_expr.return_type() else {
+        return None;
+    };
+
+    let array_length = match arg_type.as_ref() {
+        Type::Array(len, _) => *len,
+        _ => return None,
+    };
+
+    let len_bigint = BigInt::from(array_length as i64);
+    let exprx = ExprX::Const(Constant::Int(len_bigint));
+    let span = build_span_no_id(
+        format!("Builtin len call returning {}", array_length),
+        Some(call_expr.location),
+    );
+
+    Some(SpannedTyped::new(&span, &ast_type_to_vir_type(&call_expr.return_type), exprx))
+}
+
+fn builtin_zeroed(call_expr: &Call) -> Option<Expr> {
+    zero_expr_of_type(&call_expr.return_type, Some(call_expr.location))
+}
+
+fn builtin_checked_transmute(
+    call_expr: &Call,
+    mode: Mode,
+    globals: &GlobalsMap,
+    expr_to_vir: ExprConverter,
+) -> Option<Expr> {
+    let arg_expr = call_expr.arguments.first()?;
+    Some(expr_to_vir(arg_expr, mode, globals))
+}
+
+fn builtin_black_box(
+    call_expr: &Call,
+    mode: Mode,
+    globals: &GlobalsMap,
+    expr_to_vir: ExprConverter,
+) -> Option<Expr> {
+    let arg_expr = call_expr.arguments.first()?;
+    Some(expr_to_vir(arg_expr, mode, globals))
+}
+
+fn builtin_unit_noop(
+    call_expr: &Call,
+    mode: Mode,
+    globals: &GlobalsMap,
+    expr_to_stmt: StmtConverter,
+    name: &str,
+) -> Option<Expr> {
+    let mut stmts = Vec::new();
+    for arg in &call_expr.arguments {
+        stmts.push(expr_to_stmt(arg, mode, globals));
+    }
+    let span = build_span_no_id(format!("Builtin {} (no-op)", name), Some(call_expr.location));
+    let exprx = ExprX::Block(Arc::new(stmts), None);
+    Some(SpannedTyped::new(&span, &make_unit_vir_type(), exprx))
+}
+
+fn zero_expr_of_type(typ: &Type, location: Option<Location>) -> Option<Expr> {
+    match typ {
+        Type::Field | Type::Integer(..) => {
+            let span = build_span_no_id("Zero literal".to_string(), location);
+            Some(SpannedTyped::new(
+                &span,
+                &ast_type_to_vir_type(typ),
+                ExprX::Const(Constant::Int(BigInt::zero())),
+            ))
+        }
+        Type::Bool => {
+            let span = build_span_no_id("Bool false literal".to_string(), location);
+            Some(SpannedTyped::new(
+                &span,
+                &ast_type_to_vir_type(typ),
+                ExprX::Const(Constant::Bool(false)),
+            ))
+        }
+        Type::Unit => {
+            let span = build_span_no_id("Unit literal".to_string(), location);
+            Some(SpannedTyped::new(
+                &span,
+                &ast_type_to_vir_type(typ),
+                ExprX::Ctor(
+                    Dt::Tuple(0),
+                    Arc::new("tuple%0".to_string()),
+                    Arc::new(Vec::new()),
+                    None,
+                ),
+            ))
+        }
+        Type::Array(len, element_type) => {
+            let mut elements = Vec::new();
+            for _ in 0..*len {
+                elements.push(zero_expr_of_type(element_type, location)?);
+            }
+            let span = build_span_no_id("Array zero literal".to_string(), location);
+            Some(SpannedTyped::new(
+                &span,
+                &ast_type_to_vir_type(typ),
+                ExprX::ArrayLiteral(Arc::new(elements)),
+            ))
+        }
+        Type::Tuple(inner_types) => {
+            let mut fields = Vec::new();
+            for field_type in inner_types {
+                fields.push(zero_expr_of_type(field_type, location)?);
+            }
+            let span = build_span_no_id("Tuple zero literal".to_string(), location);
+            Some(mk_tuple(&span, &Arc::new(fields)))
+        }
+        _ => None,
+    }
+}

--- a/formal_verification/src/vir_backend/vir_gen/expr_to_vir/expr.rs
+++ b/formal_verification/src/vir_backend/vir_gen/expr_to_vir/expr.rs
@@ -6,7 +6,10 @@ use crate::{
         build_span, build_span_no_id,
         expr_to_vir::{
             expression_location,
-            std_functions::{DECREASES, INVARIANT, handle_fv_std_call, loop_decreases_from_call, loop_invariant_from_call},
+            std_functions::{
+                DECREASES, INVARIANT, handle_fv_std_call, loop_decreases_from_call,
+                loop_invariant_from_call,
+            },
             types::{
                 ast_const_to_vir_type_const, ast_type_to_vir_type, build_tuple_type,
                 get_binary_op_type, get_bit_not_bitwidth, get_collection_type_len,
@@ -27,7 +30,7 @@ use noirc_frontend::{
     signed_field::SignedField,
 };
 use num_bigint::{BigInt, BigUint};
-use num_traits::{One, ToPrimitive};
+use num_traits::{One, Zero};
 use vir::{
     ast::{
         AirQuant, ArithOp, AutospecUsage, BinaryOp, BinderX, BitwiseOp, CallTarget, CallTargetKind,
@@ -622,7 +625,7 @@ fn ast_call_to_vir_expr(
         return expr;
     }
 
-    if let Some(expr) = try_handle_builtin_call(call_expr) {
+    if let Some(expr) = try_handle_builtin_call(call_expr, mode, globals) {
         return expr;
     }
 
@@ -649,12 +652,7 @@ fn ast_call_to_vir_expr(
     let call_description = format!(
         "Function call {} with arguments {}",
         function_ident.name,
-        call_expr
-            .arguments
-            .iter()
-            .map(|arg| arg.to_string())
-            .collect::<Vec<String>>()
-            .join(", ")
+        call_expr.arguments.iter().map(|arg| arg.to_string()).collect::<Vec<String>>().join(", ")
     );
 
     let span = match ast_definition_to_id(&function_ident.definition) {
@@ -662,14 +660,14 @@ fn ast_call_to_vir_expr(
         None => build_span_no_id(call_description, Some(call_expr.location)),
     };
 
-    SpannedTyped::new(
-        &span,
-        &ast_type_to_vir_type(&call_expr.return_type),
-        exprx,
-    )
+    SpannedTyped::new(&span, &ast_type_to_vir_type(&call_expr.return_type), exprx)
 }
 
-fn try_handle_builtin_call(call_expr: &Call) -> Option<Expr> {
+fn try_handle_builtin_call(
+    call_expr: &Call,
+    mode: Mode,
+    globals: &BTreeMap<GlobalId, (String, Type, Expression)>,
+) -> Option<Expr> {
     let Expression::Ident(function_ident) = call_expr.func.as_ref() else {
         return None;
     };
@@ -677,15 +675,20 @@ fn try_handle_builtin_call(call_expr: &Call) -> Option<Expr> {
 
     match name.as_str() {
         "len" | "array_len" => builtin_len(call_expr),
+        "zeroed" => builtin_zeroed(call_expr),
+        "checked_transmute" => builtin_checked_transmute(call_expr, mode, globals),
+        "black_box" => builtin_black_box(call_expr, mode, globals),
+        // Ownership bookkeeping builtins become no-ops in VIR.
+        "array_refcount" | "slice_refcount" | "slice_push_back" | "slice_push_front"
+        | "slice_pop_back" | "slice_pop_front" | "slice_insert" | "slice_remove" => {
+            builtin_unit_noop(call_expr, mode, globals, name)
+        }
         _ => None,
     }
 }
 
 fn builtin_len(call_expr: &Call) -> Option<Expr> {
-    assert!(
-        call_expr.arguments.len() == 1,
-        "Expected builtin `len` to receive a single argument"
-    );
+    assert!(call_expr.arguments.len() == 1, "Expected builtin `len` to receive a single argument");
 
     let arg_expr = &call_expr.arguments[0];
     let Some(arg_type) = arg_expr.return_type() else {
@@ -704,11 +707,99 @@ fn builtin_len(call_expr: &Call) -> Option<Expr> {
         Some(call_expr.location),
     );
 
-    Some(SpannedTyped::new(
-        &span,
-        &ast_type_to_vir_type(&call_expr.return_type),
-        exprx,
-    ))
+    Some(SpannedTyped::new(&span, &ast_type_to_vir_type(&call_expr.return_type), exprx))
+}
+
+fn builtin_zeroed(call_expr: &Call) -> Option<Expr> {
+    zero_expr_of_type(&call_expr.return_type, Some(call_expr.location))
+}
+
+fn builtin_checked_transmute(
+    call_expr: &Call,
+    mode: Mode,
+    globals: &BTreeMap<GlobalId, (String, Type, Expression)>,
+) -> Option<Expr> {
+    let arg_expr = call_expr.arguments.first()?;
+    Some(ast_expr_to_vir_expr(arg_expr, mode, globals))
+}
+
+fn builtin_black_box(
+    call_expr: &Call,
+    mode: Mode,
+    globals: &BTreeMap<GlobalId, (String, Type, Expression)>,
+) -> Option<Expr> {
+    let arg_expr = call_expr.arguments.first()?;
+    Some(ast_expr_to_vir_expr(arg_expr, mode, globals))
+}
+
+fn builtin_unit_noop(
+    call_expr: &Call,
+    mode: Mode,
+    globals: &BTreeMap<GlobalId, (String, Type, Expression)>,
+    name: &str,
+) -> Option<Expr> {
+    let mut stmts = Vec::new();
+    for arg in &call_expr.arguments {
+        stmts.push(ast_expr_to_stmt(arg, mode, globals));
+    }
+    let span = build_span_no_id(format!("Builtin {} (no-op)", name), Some(call_expr.location));
+    let exprx = ExprX::Block(Arc::new(stmts), None);
+    Some(SpannedTyped::new(&span, &make_unit_vir_type(), exprx))
+}
+
+fn zero_expr_of_type(typ: &Type, location: Option<Location>) -> Option<Expr> {
+    match typ {
+        Type::Field | Type::Integer(..) => {
+            let span = build_span_no_id("Zero literal".to_string(), location);
+            Some(SpannedTyped::new(
+                &span,
+                &ast_type_to_vir_type(typ),
+                ExprX::Const(Constant::Int(BigInt::zero())),
+            ))
+        }
+        Type::Bool => {
+            let span = build_span_no_id("Bool false literal".to_string(), location);
+            Some(SpannedTyped::new(
+                &span,
+                &ast_type_to_vir_type(typ),
+                ExprX::Const(Constant::Bool(false)),
+            ))
+        }
+        Type::Unit => {
+            let span = build_span_no_id("Unit literal".to_string(), location);
+            Some(SpannedTyped::new(
+                &span,
+                &ast_type_to_vir_type(typ),
+                ExprX::Ctor(
+                    Dt::Tuple(0),
+                    Arc::new("tuple%0".to_string()),
+                    Arc::new(Vec::new()),
+                    None,
+                ),
+            ))
+        }
+        Type::Array(len, element_type) => {
+            let mut elements = Vec::new();
+            for _ in 0..*len {
+                elements.push(zero_expr_of_type(element_type, location)?);
+            }
+            let span = build_span_no_id("Array zero literal".to_string(), location);
+            Some(SpannedTyped::new(
+                &span,
+                &ast_type_to_vir_type(typ),
+                ExprX::ArrayLiteral(Arc::new(elements)),
+            ))
+        }
+        Type::Tuple(inner_types) => {
+            let mut fields = Vec::new();
+            for field_type in inner_types {
+                fields.push(zero_expr_of_type(field_type, location)?);
+            }
+            let span = build_span_no_id("Tuple zero literal".to_string(), location);
+            Some(vir::ast_util::mk_tuple(&span, &Arc::new(fields)))
+        }
+        _ => None,
+    }
 }
 
 fn ast_constrain_to_vir_expr(

--- a/formal_verification/src/vir_backend/vir_gen/expr_to_vir/mod.rs
+++ b/formal_verification/src/vir_backend/vir_gen/expr_to_vir/mod.rs
@@ -4,6 +4,7 @@ use noirc_errors::Location;
 use noirc_frontend::monomorphization::ast::{Expression, LValue, Literal};
 use vir::ast::VarIdent;
 
+pub mod builtins;
 pub mod expr;
 pub mod params;
 pub mod std_functions;

--- a/test_programs/formal_verify_success/builtin_mem_ops/Nargo.toml
+++ b/test_programs/formal_verify_success/builtin_mem_ops/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "builtin_mem_ops"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/builtin_mem_ops/src/main.nr
+++ b/test_programs/formal_verify_success/builtin_mem_ops/src/main.nr
@@ -1,0 +1,13 @@
+use std::mem::{checked_transmute, zeroed};
+
+#['ensures(result == 8)]
+fn main() -> pub Field {
+  let arr: [Field; 3] = zeroed();
+  let initial_sum = arr[0] + arr[1] + arr[2];
+
+  let mut pair: [Field; 2] = zeroed();
+  pair[0] = 4;
+  let copy: Field = checked_transmute(pair[0]);
+
+  initial_sum + pair[0] + copy
+}

--- a/test_programs/formal_verify_success/builtin_runtime_hint/Nargo.toml
+++ b/test_programs/formal_verify_success/builtin_runtime_hint/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "builtin_runtime_hint"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/builtin_runtime_hint/src/main.nr
+++ b/test_programs/formal_verify_success/builtin_runtime_hint/src/main.nr
@@ -1,0 +1,6 @@
+use std::hint::black_box;
+
+#['ensures(result == 6)]
+unconstrained fn main() -> pub Field {
+  black_box(5) + 1
+}

--- a/test_programs/formal_verify_success/vector_for_loop/Nargo.toml
+++ b/test_programs/formal_verify_success/vector_for_loop/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "unconstrained_for_loop"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/vector_for_loop/src/main.nr
+++ b/test_programs/formal_verify_success/vector_for_loop/src/main.nr
@@ -1,0 +1,7 @@
+fn main(elements: [Field; 10]) -> pub Field {
+  let mut acc = 0;
+  for x in elements {
+    acc += x;
+  }
+  acc
+}


### PR DESCRIPTION
Update VIR generation to resolve array length builtins to their constant sizes.
Extend VIR support for zeroed, checked_transmute, black_box, and ownership bookkeeping builtins by threading through their arguments as no-ops.
Add Noir fixtures covering vector loops, memory helpers, and runtime hints to exercise the new builtin handling.