### PR TITLE
fix(lowering): Fix tuple deconstruction pass

### DIFF
--- a/formal_verification/src/vir_backend/lowering/tuple_deconstruction.rs
+++ b/formal_verification/src/vir_backend/lowering/tuple_deconstruction.rs
@@ -16,58 +16,107 @@ fn fix_tuple_deconstruction(function: &mut Function) {
 /// - This function rewrites the inner block, and
 /// - Afterwards flattens it into the outer block
 fn fix_tuple_deconstruction_expression(expression: &mut Expression) {
-    if let Expression::Block(outer_block) = expression {
-        let mut blocks_to_be_flattened: Vec<(usize, Vec<Expression>)> = Vec::new();
-
-        // NOTE: enumeration done beforehand to keep real original indices
-        outer_block
-            .iter_mut()
-            .enumerate()
-            .filter_map(|(i, expression)| {
-                if let Expression::Block(inner_expressions) = expression {
-                    Some((i, inner_expressions))
-                } else {
-                    None
-                }
-            })
-            .for_each(|(i, expressions)| {
-                let let_exprs_for_deconstruct_tuple: Option<usize> = expressions
-                    .first()
-                    .and_then(|first_expression| match first_expression {
-                        Expression::Let(Let { name, expression, .. }) => Some((name, expression)),
-                        _ => None,
-                    })
-                    .and_then(
-                        |(name, expression)| if *name == "_" { Some(expression) } else { None },
-                    )
-                    .and_then(|expression| {
-                        let ty = expression.return_type()?;
-                        match ty.as_ref() {
-                            Type::Tuple(tuple_vec) => Some(tuple_vec.len()),
-                            _ => None,
-                        }
-                    });
-
-                if let Some(exprs_len) = let_exprs_for_deconstruct_tuple {
-                    for expr in expressions[1..=exprs_len].iter_mut() {
-                        assert!(matches!(expr, Expression::Let(..)),
-                            "Expected to have a follow up auto generated let expressions after tuple deconstruct assignment");
-                        if let Expression::Let(let_expr) = expr {
-                            fix_rhs_tuple_indexing(let_expr);
-                        }
-                    }
-                    blocks_to_be_flattened.push((i, expressions.clone()));
-                }
-            });
-
-        // Flatten marked blocks into the outer block
-        let mut offset = 0;
-        blocks_to_be_flattened.into_iter().for_each(|(original_index, expressions)| {
-            let added_expressions_count = expressions.len();
-            outer_block.splice(original_index + offset..original_index + offset + 1, expressions);
-            offset = offset + added_expressions_count - 1;
-        });
+    println!("Visiting expression: {}", expression);
+    match expression {
+        Expression::Block(expressions) => {
+            flatten_blocks_made_of_tuple_deconstruction_expressions(expressions)
+        }
+        Expression::Unary(unary) => fix_tuple_deconstruction_expression(&mut unary.rhs),
+        Expression::Binary(binary) => {
+            fix_tuple_deconstruction_expression(&mut binary.lhs);
+            fix_tuple_deconstruction_expression(&mut binary.rhs);
+        }
+        Expression::Index(index) => {
+            fix_tuple_deconstruction_expression(&mut index.collection);
+            fix_tuple_deconstruction_expression(&mut index.index);
+        }
+        Expression::Cast(cast) => fix_tuple_deconstruction_expression(&mut cast.lhs),
+        Expression::For(for_loop) => fix_tuple_deconstruction_expression(&mut for_loop.block),
+        Expression::Loop(expression) => fix_tuple_deconstruction_expression(expression),
+        Expression::While(while_loop) => fix_tuple_deconstruction_expression(&mut while_loop.body),
+        Expression::If(if_expr) => {
+            fix_tuple_deconstruction_expression(&mut if_expr.consequence);
+            if let Some(alt) = if_expr.alternative.as_mut() {
+                fix_tuple_deconstruction_expression(alt);
+            }
+        }
+        Expression::Match(match_expr) => (), // TODO(totel): Currently not supported in the VIR gen module
+        Expression::Tuple(expressions) => {
+            expressions.iter_mut().for_each(|expr| fix_tuple_deconstruction_expression(expr));
+        }
+        Expression::ExtractTupleField(expression, _) => {
+            fix_tuple_deconstruction_expression(expression)
+        }
+        Expression::Call(call) => {
+            call.arguments.iter_mut().for_each(|expr| fix_tuple_deconstruction_expression(expr));
+        }
+        Expression::Let(let_expr) => fix_tuple_deconstruction_expression(&mut let_expr.expression),
+        Expression::Constrain(expression, location, rhs) => {
+            fix_tuple_deconstruction_expression(expression);
+            if let Some(rhs_inner) = rhs.as_mut() {
+                fix_tuple_deconstruction_expression(&mut rhs_inner.as_mut().0);
+            }
+        }
+        Expression::Assign(assign) => fix_tuple_deconstruction_expression(&mut assign.expression),
+        Expression::Semi(expression) => fix_tuple_deconstruction_expression(expression),
+        Expression::Clone(expression) => fix_tuple_deconstruction_expression(expression),
+        Expression::Drop(expression) => fix_tuple_deconstruction_expression(expression),
+        _ => (),
     }
+}
+
+fn flatten_blocks_made_of_tuple_deconstruction_expressions(block: &mut Vec<Expression>) {
+    let mut blocks_to_be_flattened: Vec<(usize, Vec<Expression>)> = Vec::new();
+
+    // NOTE: enumeration done beforehand to keep real original indices
+    block
+     .iter_mut()
+     .enumerate()
+     .filter_map(|(i, expression)| {
+        fix_tuple_deconstruction_expression(expression);
+         if let Expression::Block(inner_expressions) = expression {
+             Some((i, inner_expressions))
+         } else {
+             None
+         }
+     })
+     .for_each(|(i, expressions)| {
+        let let_exprs_for_deconstruct_tuple: Option<usize> = expressions
+            .first()
+            .and_then(|first_expression| match first_expression {
+                Expression::Let(Let { name, expression, .. }) => Some((name, expression)),
+                _ => None,
+            })
+            .and_then(
+                |(name, expression)| if *name == "_" { Some(expression) } else { None },
+            )
+           .and_then(|expression| {
+              let ty = expression.return_type()?;
+              match ty.as_ref() {
+               Type::Tuple(tuple_vec) => Some(tuple_vec.len()),
+               _ => None,
+               }
+           });
+
+        if let Some(exprs_len) = let_exprs_for_deconstruct_tuple {
+            for expr in expressions[1..=exprs_len].iter_mut() {
+                assert!(matches!(expr, Expression::Let(..)),
+                    "Expected to have a follow up auto generated let expressions after tuple deconstruct assignment");
+                if let Expression::Let(let_expr) = expr {
+                    fix_rhs_tuple_indexing(let_expr);
+                }
+            }
+            blocks_to_be_flattened.push((i, expressions.clone()));
+        }
+    });
+
+    // Flatten marked blocks into the outer block
+    let mut offset = 0;
+    blocks_to_be_flattened.into_iter().for_each(|(original_index, expressions)| {
+        let added_expressions_count = expressions.len();
+        block.splice(original_index + offset..original_index + offset + 1, expressions);
+        offset = offset + added_expressions_count - 1;
+    });
 }
 
 fn fix_rhs_tuple_indexing(expr: &mut Let) {

--- a/test_programs/formal_verify_success/binary_search_v1/Nargo.toml
+++ b/test_programs/formal_verify_success/binary_search_v1/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "binary_search"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/binary_search_v1/src/main.nr
+++ b/test_programs/formal_verify_success/binary_search_v1/src/main.nr
@@ -1,0 +1,71 @@
+#['requires( (forall(|i, j| (0 <= i) & (i <= j) & (j < 30) ==> arr[i] <= arr[j] )))]
+#['ensures( (exists(|i| (0 <= i) & (i < 30) & (arr[i] == find))) ==> result == true)]
+#['ensures( (forall(|i| (0 <= i) & (i < 30) & (arr[i] != find))) ==> result == false)]
+fn main(arr: [u32; 30], find: u32) -> pub bool {
+    let mut lind = 0;
+    let mut hind = arr.len() - 1;
+    let mut found = false;
+
+    // Perform up to 6 iterations ((log2(30) ~= 5) + 1)
+    for _ in 0..6 {
+        // assert((lind > hind) ==> found == false);
+
+        let (new_lind, new_hind, new_found) = binary_search_step(arr, find, lind, hind, found);
+        // assert((arr[(lind + hind) / 2] == find) ==> new_found == true);
+
+        if (check(new_lind, new_hind)) {
+            lind = new_lind;
+            hind = new_hind;
+            found = new_found;
+        } else {
+            found = false;
+        }
+    }
+
+    found
+}
+
+#['ensures(lind <= hind ==> result == true)]
+#['ensures(lind > hind ==> result == false)]
+fn check(lind: u32, hind: u32) -> bool {
+    if (lind <= hind) { true } else { false }
+}
+
+#['requires(hind < 30)]
+#['requires(lind <= 30)]
+#['requires((lind > hind) ==> found == false)]
+#['ensures((found == true) ==> ((result.0 == lind) & (result.1 == hind) & (result.2 == true) ) )]
+#['ensures((lind > hind) ==> ((result.0 == lind) & (result.1 == hind) & (result.2 == false)) )]
+#['ensures((lind <= hind) & (arr[(hind + lind) / 2] == find) 
+                      ==> ((result.0 == lind) & (result.1 == hind) & (result.2 == true)) )]
+#['ensures((found == false) & (lind <= hind) & (((hind + lind) / 2) != 0) & (arr[(hind + lind) / 2] < find) 
+                      ==> ((result.0 == ((hind + lind) / 2) + 1) & (result.1 == hind) & (result.2 == false)) )]
+#['ensures((found == false) & (lind <= hind) & (arr[(hind + lind) / 2] > find) & (((hind + lind) / 2) != 0) 
+                     ==> ((result.0 == lind) & (result.1 == (((hind + lind) / 2) - 1)) & (result.2 == false)) )]
+#['ensures((found == false) & (lind <= hind) & (arr[(hind + lind) / 2] > find) & (((hind + lind) / 2) == 0) 
+                     ==> ((result.0 == lind) & (result.1 == hind) & (result.2 == false)) )]
+#['ensures((found == false) & (lind <= hind) & (arr[(hind + lind) / 2] < find) & (((hind + lind) / 2) == 0) 
+                     ==> ((result.0 == lind + 1) & (result.1 == hind) & (result.2 == false)) )]
+#['ensures(result.1 < 30)]
+#['ensures(result.0 <= 30)]
+fn binary_search_step(arr: [u32; 30], find: u32, lind: u32, hind: u32, found: bool) -> (u32, u32, bool) {
+    // found == true
+    if found & lind <= hind {
+        (lind, hind, true)
+    } else if lind <= hind {
+        let mid = (hind + lind) / 2;
+        let num = arr[mid];
+
+        if num == find {
+            (lind, hind, true)
+        } else if num < find {
+            (mid + 1, hind, false)
+        } else if mid == 0 {
+            (lind, hind, false)
+        } else {
+            (lind, mid - 1, false)
+        }
+    } else {
+        (lind, hind, false)
+    }
+}

--- a/test_programs/formal_verify_success/binary_search_v2/Nargo.toml
+++ b/test_programs/formal_verify_success/binary_search_v2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "binary_search_v2"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.35.0"
+
+[dependencies]

--- a/test_programs/formal_verify_success/binary_search_v2/src/main.nr
+++ b/test_programs/formal_verify_success/binary_search_v2/src/main.nr
@@ -1,0 +1,60 @@
+#['requires( (forall(|i, j| (0 <= i) & (i <= j) & (j < 200) ==> arr[i] <= arr[j] )))]
+#['ensures( (exists(|i| (0 <= i) & (i < 200) & (arr[i] == find))) ==> result == true)]
+#['ensures( (forall(|i| (0 <= i) & (i < 200) & (arr[i] != find))) ==> result == false)]
+fn main(arr: [u32; 200], find: u32) -> pub bool {
+    let mut lind = 0;
+    let mut hind = arr.len() - 1;
+    let mut found = false;
+
+    // Perform up to 5 iterations ((log2(200) ~= 7.64))
+    for _ in 0..8 {
+        let (new_lind, new_hind, new_found) = binary_search_step(arr, find, lind, hind, found);
+
+        lind = new_lind;
+        hind = new_hind;
+        found = new_found;
+    }
+
+    found
+}
+
+#['requires(hind < 200)]
+#['requires(lind <= 200)]
+#['requires((lind > hind) ==> found == false)]
+#['ensures(result.1 < 200)]
+#['ensures(result.0 <= 200)]
+#['ensures(found == true ==> ((result.0 == lind) & (result.1 == hind) & (result.2 == true) ))]
+#['ensures(lind > hind ==> ((result.0 == lind) & (result.1 == hind) & (result.2 == false)) )]
+#['ensures( (found == false) & (lind == hind) & (arr[(hind+lind) / 2] == find)  ==> (result.0 == lind) & (result.1 == hind) & (result.2 == true))]
+#['ensures( (found == false) & (lind == hind) & (arr[(hind+lind) / 2] != find)  ==> (result.0 == lind) & (result.1 == hind) & (result.2 == false))]
+#['ensures( ((found == false) & (lind < hind) & (arr[(hind+lind) / 2] == find)) 
+                ==> (result.0 == lind) & (result.1 == hind) & (result.2 == true))]
+#['ensures((found == false) & (lind < hind) & (arr[(hind + lind) / 2] < find) 
+                      ==> ((result.0 == ((hind + lind) / 2) + 1) & (result.1 == hind) & (result.2 == false)) )]
+#['ensures((found == false) & (lind < hind) & (arr[(hind + lind) / 2] > find) 
+                      ==> ((result.0 == lind) & (result.1 == ((hind + lind) / 2)) & (result.2 == false)) )]
+fn binary_search_step(arr: [u32; 200], find: u32, lind: u32, hind: u32, found: bool) -> (u32, u32, bool) {
+    // found == true
+    if found {
+        (lind, hind, true)
+    }
+    else if lind >= hind {
+        if (lind == hind) & (arr[(lind + hind) / 2] == find) {
+            (lind, hind, true)
+        } else {
+            (lind, hind, found)
+        }
+    } else {
+        let mid = (hind + lind) / 2;
+        let num = arr[mid];
+
+        if num == find {
+            (lind, hind, true)
+        } else if num < find {
+            (mid + 1, hind, false)
+        } else {
+            (lind, mid, false)
+        }
+    }
+}
+


### PR DESCRIPTION
The tuple deconstruction lowering pass has now been implemented recursively. Before it wasn't visiting nested expressions.

With this fix, now both of our binary search tests pass.